### PR TITLE
Use EnumSet for the checker options

### DIFF
--- a/src/main/java/de/thetaphi/forbiddenapis/AbstractCheckMojo.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/AbstractCheckMojo.java
@@ -16,6 +16,8 @@ package de.thetaphi.forbiddenapis;
  * limitations under the License.
  */
 
+import static de.thetaphi.forbiddenapis.Checker.Option.*;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -32,6 +34,7 @@ import java.net.URLClassLoader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 
@@ -207,7 +210,12 @@ public abstract class AbstractCheckMojo extends AbstractMojo {
       ClassLoader.getSystemClassLoader();
     
     try {
-      final Checker checker = new Checker(loader, internalRuntimeForbidden, failOnMissingClasses, failOnViolation, failOnUnresolvableSignatures) {
+      final EnumSet<Checker.Option> options = EnumSet.noneOf(Checker.Option.class);
+      if (internalRuntimeForbidden) options.add(INTERNAL_RUNTIME_FORBIDDEN);
+      if (failOnMissingClasses) options.add(FAIL_ON_MISSING_CLASSES);
+      if (failOnViolation) options.add(FAIL_ON_VIOLATION);
+      if (failOnUnresolvableSignatures) options.add(FAIL_ON_UNRESOLVABLE_SIGNATURES);
+      final Checker checker = new Checker(loader, options) {
         @Override
         protected void logError(String msg) {
           log.error(msg);

--- a/src/main/java/de/thetaphi/forbiddenapis/AntTask.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/AntTask.java
@@ -18,6 +18,8 @@ package de.thetaphi.forbiddenapis;
  * limitations under the License.
  */
 
+import static de.thetaphi.forbiddenapis.Checker.Option.*;
+
 import org.apache.tools.ant.AntClassLoader;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
@@ -36,6 +38,7 @@ import org.apache.tools.ant.types.resources.StringResource;
 import java.io.IOException;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -77,7 +80,12 @@ public final class AntTask extends Task {
       classFiles.setProject(getProject());
       apiSignatures.setProject(getProject());
       
-      final Checker checker = new Checker(loader, internalRuntimeForbidden, failOnMissingClasses, failOnViolation, failOnUnresolvableSignatures) {
+      final EnumSet<Checker.Option> options = EnumSet.noneOf(Checker.Option.class);
+      if (internalRuntimeForbidden) options.add(INTERNAL_RUNTIME_FORBIDDEN);
+      if (failOnMissingClasses) options.add(FAIL_ON_MISSING_CLASSES);
+      if (failOnViolation) options.add(FAIL_ON_VIOLATION);
+      if (failOnUnresolvableSignatures) options.add(FAIL_ON_UNRESOLVABLE_SIGNATURES);
+      final Checker checker = new Checker(loader, options) {
         @Override
         protected void logError(String msg) {
           log(msg, Project.MSG_ERR);

--- a/src/main/java/de/thetaphi/forbiddenapis/CliMain.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/CliMain.java
@@ -16,11 +16,14 @@ package de.thetaphi.forbiddenapis;
  * limitations under the License.
  */
 
+import static de.thetaphi.forbiddenapis.Checker.Option.*;
+
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.Locale;
 import java.net.JarURLConnection;
 import java.net.URLConnection;
@@ -220,8 +223,11 @@ public final class CliMain {
 
     final URLClassLoader loader = URLClassLoader.newInstance(urls, ClassLoader.getSystemClassLoader());
     try {
-      final Checker checker = new Checker(loader, cmd.hasOption(internalruntimeforbiddenOpt.getLongOpt()),
-        !cmd.hasOption(allowmissingclassesOpt.getLongOpt()), true, !cmd.hasOption(allowunresolvablesignaturesOpt.getLongOpt())) {
+      final EnumSet<Checker.Option> options = EnumSet.of(FAIL_ON_VIOLATION);
+      if (cmd.hasOption(internalruntimeforbiddenOpt.getLongOpt())) options.add(INTERNAL_RUNTIME_FORBIDDEN);
+      if (!cmd.hasOption(allowmissingclassesOpt.getLongOpt())) options.add(FAIL_ON_MISSING_CLASSES);
+      if (!cmd.hasOption(allowunresolvablesignaturesOpt.getLongOpt())) options.add(FAIL_ON_UNRESOLVABLE_SIGNATURES);
+      final Checker checker = new Checker(loader, options) {
         @Override
         protected void logError(String msg) {
           CliMain.this.logError(msg);

--- a/src/test/java/de/thetaphi/forbiddenapis/CheckerSetupTest.java
+++ b/src/test/java/de/thetaphi/forbiddenapis/CheckerSetupTest.java
@@ -16,6 +16,7 @@ package de.thetaphi.forbiddenapis;
  * limitations under the License.
  */
 
+import static de.thetaphi.forbiddenapis.Checker.Option.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
 
@@ -29,7 +30,7 @@ public final class CheckerSetupTest {
   @SuppressForbidden
   static final class MyChecker extends Checker {
     public MyChecker() {
-      super(ClassLoader.getSystemClassLoader(), true, true, true, true);
+      super(ClassLoader.getSystemClassLoader(), INTERNAL_RUNTIME_FORBIDDEN, FAIL_ON_MISSING_CLASSES, FAIL_ON_VIOLATION, FAIL_ON_UNRESOLVABLE_SIGNATURES);
     }
 
     @Override


### PR DESCRIPTION
This minimizes problems caused by the long chain of booleans, so makes code more readable.