### PR TITLE
Make Checker extendable from outside of the package

### DIFF
--- a/src/main/java/de/thetaphi/forbiddenapis/Checker.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/Checker.java
@@ -334,11 +334,11 @@ public abstract class Checker implements RelatedClassLookup {
     if (!name.matches("[A-Za-z0-9\\-\\.]+")) {
       throw new ParseException("Invalid bundled signature reference: " + name);
     }
-    InputStream in = this.getClass().getResourceAsStream("signatures/" + name + ".txt");
+    InputStream in = getBundledResource("signatures/" + name + ".txt");
     // automatically expand the compiler version in here (for jdk-* signatures without version):
     if (in == null && jdkTargetVersion != null && name.startsWith("jdk-") && !name.matches(".*?\\-\\d\\.\\d")) {
       name = name + "-" + jdkTargetVersion;
-      in = this.getClass().getResourceAsStream("signatures/" + name + ".txt");
+      in = getBundledResource("signatures/" + name + ".txt");
     }
     if (in == null) {
       throw new FileNotFoundException("Bundled signatures resource not found: " + name);
@@ -456,5 +456,15 @@ public abstract class Checker implements RelatedClassLookup {
       logInfo(message);
     }
   }
-  
+
+  /**
+   * Get an {@link InputStream} for the selected resource at the {@code path} relative to
+   *  to a resource from the {@code de.thetaphi.forbiddenapis} package.
+   *
+   * @param path The relative path
+   * @return {@code null} if {@code path} does not match a known resource.
+   */
+  private InputStream getBundledResource(String path) {
+    return Checker.class.getResourceAsStream(path);
+  }  
 }


### PR DESCRIPTION
Currently, using `this.getClass()` forces the abstract class to get the extension's package to look for resources. This change forces it to use `Checker.class` so that extension code can work.

I was tempted to make the `parseBundledSignatures ` function non-`final` so that extensions could provide their own bundled resources as well, but I do not need that functionality yet.