### PR TITLE
Package refactoring of Cli, Ant, Maven

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -97,7 +97,7 @@
   <property name="documentation-dir" location="build/docs"/>
   <property name="test-results-dir" location="build/test-results"/>
   
-  <property name="cli-classname" value="de.thetaphi.forbiddenapis.CliMain"/>
+  <property name="cli-classname" value="de.thetaphi.forbiddenapis.cli.CliMain"/>
 
   <!-- define Maven coordinates -->
   <property name="groupId" value="de.thetaphi" />
@@ -333,7 +333,7 @@
           <zips><fileset refid="fileset.bundle"/></zips>
         </archives>
       </restrict>
-      <keep pattern="de.thetaphi.forbiddenapis.*"/>
+      <keep pattern="de.thetaphi.forbiddenapis.**"/>
       <rule pattern="org.objectweb.asm.**" result="de.thetaphi.forbiddenapis.asm.@1"/>
       <rule pattern="org.apache.commons.**" result="de.thetaphi.forbiddenapis.commons.@1"/>
       <rule pattern="org.codehaus.plexus.**" result="de.thetaphi.forbiddenapis.plexus.@1"/>
@@ -424,7 +424,7 @@
     description="Checks bundled signatures file corresponding to the current JVM. Run after every update!"/>
     
   <target name="-install-forbiddenapi-task" depends="compile" unless="installed.forbiddenapi-task">
-    <taskdef name="forbiddenapis" classname="de.thetaphi.forbiddenapis.AntTask" classpathref="path.main-run"/>
+    <taskdef name="forbiddenapis" classname="de.thetaphi.forbiddenapis.ant.AntTask" classpathref="path.main-run"/>
     <property name="installed.forbiddenapi-task" value="true"/>
   </target>
   

--- a/src/main/java/de/thetaphi/forbiddenapis/AntTask.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/AntTask.java
@@ -1,0 +1,37 @@
+package de.thetaphi.forbiddenapis;
+
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+
+/*
+ * (C) Copyright Uwe Schindler (Generics Policeman) and others.
+ * Parts of this work are licensed to the Apache Software Foundation (ASF)
+ * under one or more contributor license agreements.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * {@inheritDoc}
+ * @deprecated Use {@link de.thetaphi.forbiddenapis.ant.AntTask} instead.
+ */
+@Deprecated
+public final class AntTask extends de.thetaphi.forbiddenapis.ant.AntTask {
+  
+  @Override
+  public void execute() throws BuildException {
+    log("DEPRECATED-WARNING: Please change your build.xml to use new task class de.thetaphi.forbiddenapis.ant.AntTask", Project.MSG_WARN);
+    super.execute();
+  }
+  
+}

--- a/src/main/java/de/thetaphi/forbiddenapis/AntTask.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/AntTask.java
@@ -1,8 +1,5 @@
 package de.thetaphi.forbiddenapis;
 
-import org.apache.tools.ant.BuildException;
-import org.apache.tools.ant.Project;
-
 /*
  * (C) Copyright Uwe Schindler (Generics Policeman) and others.
  * Parts of this work are licensed to the Apache Software Foundation (ASF)
@@ -21,6 +18,11 @@ import org.apache.tools.ant.Project;
  * limitations under the License.
  */
 
+import java.util.Locale;
+
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+
 /**
  * {@inheritDoc}
  * @deprecated Use {@link de.thetaphi.forbiddenapis.ant.AntTask} instead.
@@ -30,7 +32,8 @@ public final class AntTask extends de.thetaphi.forbiddenapis.ant.AntTask {
   
   @Override
   public void execute() throws BuildException {
-    log("DEPRECATED-WARNING: Please change your build.xml to use new task class de.thetaphi.forbiddenapis.ant.AntTask", Project.MSG_WARN);
+    log(String.format(Locale.ENGLISH, "DEPRECATED-WARNING: Please change your build.xml to use new task class '%s'",
+        getClass().getSuperclass().getName()), Project.MSG_WARN);
     super.execute();
   }
   

--- a/src/main/java/de/thetaphi/forbiddenapis/WrapperRuntimeException.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/WrapperRuntimeException.java
@@ -17,7 +17,7 @@ package de.thetaphi.forbiddenapis;
  */
 
 @SuppressWarnings("serial")
-public final class WrapperRuntimeException extends RuntimeException {
+final class WrapperRuntimeException extends RuntimeException {
 
   public WrapperRuntimeException(Exception e) {
     super(e);

--- a/src/main/java/de/thetaphi/forbiddenapis/ant/AntTask.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/ant/AntTask.java
@@ -1,4 +1,4 @@
-package de.thetaphi.forbiddenapis;
+package de.thetaphi.forbiddenapis.ant;
 
 /*
  * (C) Copyright Uwe Schindler (Generics Policeman) and others.
@@ -34,6 +34,11 @@ import org.apache.tools.ant.types.ResourceCollection;
 import org.apache.tools.ant.types.resources.FileResource;
 import org.apache.tools.ant.types.resources.Resources;
 import org.apache.tools.ant.types.resources.StringResource;
+
+import de.thetaphi.forbiddenapis.Checker;
+import de.thetaphi.forbiddenapis.ForbiddenApiException;
+import de.thetaphi.forbiddenapis.Logger;
+import de.thetaphi.forbiddenapis.ParseException;
 
 import java.io.IOException;
 import java.io.File;

--- a/src/main/java/de/thetaphi/forbiddenapis/ant/AntTask.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/ant/AntTask.java
@@ -54,7 +54,7 @@ import java.util.Locale;
  * In contrast to other ANT tasks, this tool does only visit the given classpath
  * and the system classloader, not ANT's class loader.
  */
-public final class AntTask extends Task {
+public class AntTask extends Task {
 
   private final Resources classFiles = new Resources();
   private final Resources apiSignatures = new Resources();

--- a/src/main/java/de/thetaphi/forbiddenapis/ant/BundledSignaturesType.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/ant/BundledSignaturesType.java
@@ -1,4 +1,4 @@
-package de.thetaphi.forbiddenapis;
+package de.thetaphi.forbiddenapis.ant;
 
 /*
  * (C) Copyright Uwe Schindler (Generics Policeman) and others.
@@ -18,16 +18,16 @@ package de.thetaphi.forbiddenapis;
 
 import org.apache.tools.ant.ProjectComponent;
 
-public final class SuppressAnnotationType extends ProjectComponent {
+public final class BundledSignaturesType extends ProjectComponent {
 
-  private String classname = null;
+  private String name = null;
   
-  public void setClassname(String classname) {
-    this.classname = classname;
+  public void setName(String name) {
+    this.name = name;
   }
   
-  public String getClassname() {
-    return classname;
+  public String getName() {
+    return name;
   }
 
 }

--- a/src/main/java/de/thetaphi/forbiddenapis/ant/SuppressAnnotationType.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/ant/SuppressAnnotationType.java
@@ -1,4 +1,4 @@
-package de.thetaphi.forbiddenapis;
+package de.thetaphi.forbiddenapis.ant;
 
 /*
  * (C) Copyright Uwe Schindler (Generics Policeman) and others.
@@ -18,16 +18,16 @@ package de.thetaphi.forbiddenapis;
 
 import org.apache.tools.ant.ProjectComponent;
 
-public final class BundledSignaturesType extends ProjectComponent {
+public final class SuppressAnnotationType extends ProjectComponent {
 
-  private String name = null;
+  private String classname = null;
   
-  public void setName(String name) {
-    this.name = name;
+  public void setClassname(String classname) {
+    this.classname = classname;
   }
   
-  public String getName() {
-    return name;
+  public String getClassname() {
+    return classname;
   }
 
 }

--- a/src/main/java/de/thetaphi/forbiddenapis/cli/CliMain.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/cli/CliMain.java
@@ -306,20 +306,6 @@ public final class CliMain {
     }
   }
   
-  @SuppressWarnings("serial")
-  public static final class ExitException extends Exception {
-    public final int exitCode;
-    
-    public ExitException(int exitCode) {
-      this(exitCode, null);
-    }
-    
-    public ExitException(int exitCode, String message) {
-      super(message);
-      this.exitCode = exitCode;
-    }
-  }
-
   @SuppressForbidden
   public static void main(String... args) {
     try {

--- a/src/main/java/de/thetaphi/forbiddenapis/cli/CliMain.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/cli/CliMain.java
@@ -1,4 +1,4 @@
-package de.thetaphi.forbiddenapis;
+package de.thetaphi.forbiddenapis.cli;
 
 /*
  * (C) Copyright Uwe Schindler (Generics Policeman) and others.
@@ -39,8 +39,14 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.PosixParser;
-
 import org.codehaus.plexus.util.DirectoryScanner;
+
+import de.thetaphi.forbiddenapis.Checker;
+import de.thetaphi.forbiddenapis.ForbiddenApiException;
+import de.thetaphi.forbiddenapis.Logger;
+import de.thetaphi.forbiddenapis.ParseException;
+import de.thetaphi.forbiddenapis.StdIoLogger;
+import de.thetaphi.forbiddenapis.SuppressForbidden;
 
 /**
  * CLI class with a static main() method

--- a/src/main/java/de/thetaphi/forbiddenapis/cli/ExitException.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/cli/ExitException.java
@@ -4,7 +4,7 @@ package de.thetaphi.forbiddenapis.cli;
  * Used by the CLI to signal process exit with a specific exit code
  */
 @SuppressWarnings("serial")
-public final class ExitException extends Exception {
+final class ExitException extends Exception {
   public final int exitCode;
   
   public ExitException(int exitCode) {

--- a/src/main/java/de/thetaphi/forbiddenapis/cli/ExitException.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/cli/ExitException.java
@@ -1,0 +1,18 @@
+package de.thetaphi.forbiddenapis.cli;
+
+/**
+ * Used by the CLI to signal process exit with a specific exit code
+ */
+@SuppressWarnings("serial")
+public final class ExitException extends Exception {
+  public final int exitCode;
+  
+  public ExitException(int exitCode) {
+    this(exitCode, null);
+  }
+  
+  public ExitException(int exitCode, String message) {
+    super(message);
+    this.exitCode = exitCode;
+  }
+}

--- a/src/main/java/de/thetaphi/forbiddenapis/maven/AbstractCheckMojo.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/maven/AbstractCheckMojo.java
@@ -29,7 +29,6 @@ import de.thetaphi.forbiddenapis.Checker;
 import de.thetaphi.forbiddenapis.ForbiddenApiException;
 import de.thetaphi.forbiddenapis.Logger;
 import de.thetaphi.forbiddenapis.ParseException;
-import de.thetaphi.forbiddenapis.Checker.Option;
 
 import java.io.Closeable;
 import java.io.File;

--- a/src/main/java/de/thetaphi/forbiddenapis/maven/AbstractCheckMojo.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/maven/AbstractCheckMojo.java
@@ -1,4 +1,4 @@
-package de.thetaphi.forbiddenapis;
+package de.thetaphi.forbiddenapis.maven;
 
 /*
  * (C) Copyright Uwe Schindler (Generics Policeman) and others.
@@ -24,6 +24,12 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.DirectoryScanner;
+
+import de.thetaphi.forbiddenapis.Checker;
+import de.thetaphi.forbiddenapis.ForbiddenApiException;
+import de.thetaphi.forbiddenapis.Logger;
+import de.thetaphi.forbiddenapis.ParseException;
+import de.thetaphi.forbiddenapis.Checker.Option;
 
 import java.io.Closeable;
 import java.io.File;

--- a/src/main/java/de/thetaphi/forbiddenapis/maven/CheckMojo.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/maven/CheckMojo.java
@@ -1,4 +1,4 @@
-package de.thetaphi.forbiddenapis;
+package de.thetaphi.forbiddenapis.maven;
 
 /*
  * (C) Copyright Uwe Schindler (Generics Policeman) and others.

--- a/src/main/java/de/thetaphi/forbiddenapis/maven/TestCheckMojo.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/maven/TestCheckMojo.java
@@ -1,4 +1,4 @@
-package de.thetaphi.forbiddenapis;
+package de.thetaphi.forbiddenapis.maven;
 
 /*
  * (C) Copyright Uwe Schindler (Generics Policeman) and others.

--- a/src/main/resources/de/thetaphi/forbiddenapis/antlib.xml
+++ b/src/main/resources/de/thetaphi/forbiddenapis/antlib.xml
@@ -15,5 +15,5 @@
  * limitations under the License.
 -->
 <antlib>
-  <taskdef name="forbiddenapis" classname="de.thetaphi.forbiddenapis.AntTask"/>
+  <taskdef name="forbiddenapis" classname="de.thetaphi.forbiddenapis.ant.AntTask"/>
 </antlib>

--- a/src/test/antunit/TestDeprecatedTask.xml
+++ b/src/test/antunit/TestDeprecatedTask.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * (C) Copyright Uwe Schindler (Generics Policeman) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+-->
+<project xmlns:au="antlib:org.apache.ant.antunit">
+
+  <taskdef name="forbiddenapis-deprecated" classname="de.thetaphi.forbiddenapis.AntTask" classpath="${jar-file}"/>
+
+  <target name="testMySelf">
+    <forbiddenapis-deprecated internalRuntimeForbidden="true" classpathref="path.all">
+      <fileset dir="${antunit.main.classes}"/>
+      <bundledsignatures name="jdk-unsafe-${jdk.version}"/>
+      <bundledsignatures name="jdk-deprecated-${jdk.version}"/>
+    </forbiddenapis-deprecated>
+    <au:assertLogContains level="info" text=" 0 error(s)."/> 
+    <au:assertLogContains level="warn" text="DEPRECATED-WARNING"/> 
+  </target>
+    
+</project>

--- a/src/test/antunit/TestFinalJAR.xml
+++ b/src/test/antunit/TestFinalJAR.xml
@@ -16,7 +16,7 @@
 -->
 <project xmlns:au="antlib:org.apache.ant.antunit">
 
-  <taskdef name="forbiddenapis-jar" classname="de.thetaphi.forbiddenapis.AntTask" classpath="${jar-file}"/>
+  <taskdef name="forbiddenapis-jar" classname="de.thetaphi.forbiddenapis.ant.AntTask" classpath="${jar-file}"/>
 
   <target name="testMySelfWithFinalJAR1">
     <forbiddenapis-jar internalRuntimeForbidden="true" classpathref="path.all">


### PR DESCRIPTION
This PR will refactor the package structure of forbidden-apis:

- Move all "interfaces" (CLI, ANT, Maven) to separate Java packages. This may help with #66, but is done for better separation
- For a while, I will keep the AntTask in the main package, because Ant users often use direct package names in their taskdef (instead of the antlib.xml). Those will get a warning message about deprecation
- I also moved some inner classes out (CliMain's ExitException)