### PR TITLE
Switch default Maven lifecycle phase to "verify"

### DIFF
--- a/src/main/java/de/thetaphi/forbiddenapis/maven/CheckMojo.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/maven/CheckMojo.java
@@ -33,7 +33,7 @@ import java.util.List;
  * <em>In most cases its enough to rename the goal on update, the older v1.0 properties are still available.</em>
  * @since 1.2
  */
-@Mojo(name = "check", threadSafe = true, requiresProject = true, requiresDependencyResolution = ResolutionScope.COMPILE, defaultPhase = LifecyclePhase.PROCESS_CLASSES)
+@Mojo(name = "check", threadSafe = true, requiresProject = true, requiresDependencyResolution = ResolutionScope.COMPILE, defaultPhase = LifecyclePhase.VERIFY)
 public final class CheckMojo extends AbstractCheckMojo {
 
   /**

--- a/src/main/java/de/thetaphi/forbiddenapis/maven/TestCheckMojo.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/maven/TestCheckMojo.java
@@ -30,7 +30,7 @@ import java.util.List;
  * At least one signature must be given, using any of the corresponding optional parameters.
  * @since 1.2
  */
-@Mojo(name = "testCheck", threadSafe = true, requiresProject = true, requiresDependencyResolution = ResolutionScope.TEST, defaultPhase = LifecyclePhase.PROCESS_TEST_CLASSES)
+@Mojo(name = "testCheck", threadSafe = true, requiresProject = true, requiresDependencyResolution = ResolutionScope.TEST, defaultPhase = LifecyclePhase.VERIFY)
 public final class TestCheckMojo extends AbstractCheckMojo {
 
   /**


### PR DESCRIPTION
A lot of people complained about this, because its impossible to debug tests with System-Printouts. It is also not really the Maven standard to do "quality checks" in the process-classes phases. The correct phase is "verify".

Most people changed the phase in their pom.xml, this PR will change the default phase. People who still want to do this in process-(test-)classes can do so in their pom.xml.