### PR TITLE
Switch to Gradle 2.3 minimum requirement

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -28,8 +28,9 @@
     <dependency org="org.apache.maven" name="maven-plugin-api" rev="2.0" conf="build"/>
     <dependency org="org.apache.maven.plugin-tools" name="maven-plugin-annotations" rev="3.2" conf="build"/>
     <!-- we compile against older Gradle 1.12 version (latest of 1.x), because 1.x still works with Java 1.5: -->
-    <dependency org="org.gradle" name="gradle-core" rev="1.12" conf="build"/>
-    <dependency org="org.gradle" name="gradle-base-services" rev="1.12" conf="build"/>
+    <dependency org="org.gradle" name="gradle-core" rev="2.3" conf="build"/>
+    <dependency org="org.gradle" name="gradle-base-services" rev="2.3" conf="build"/>
+    <dependency org="org.gradle" name="gradle-base-services-groovy" rev="2.3" conf="build"/>
     <dependency org="org.slf4j" name="slf4j-api" rev="1.7.5" conf="build"/>
     <!-- Gradle also needs Groovy, but we need it as build tool, too: -->
     <dependency org="org.codehaus.groovy" name="groovy-all" rev="2.2.2" conf="build,buildtools"/>

--- a/src/main/java/de/thetaphi/forbiddenapis/gradle/CheckForbiddenApis.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/gradle/CheckForbiddenApis.java
@@ -48,6 +48,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.ParallelizableTask;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.VerificationTask;
@@ -60,9 +61,10 @@ import de.thetaphi.forbiddenapis.Logger;
 import de.thetaphi.forbiddenapis.ParseException;
 
 /**
- * ForbiddenApis Gradle Task
- * @since 1.9
+ * ForbiddenApis Gradle Task (requires at least Gradle 2.3)
+ * @since 2.0
  */
+@ParallelizableTask
 public class CheckForbiddenApis extends DefaultTask implements PatternFilterable,VerificationTask {
   
   private final CheckForbiddenApisExtension data = new CheckForbiddenApisExtension();

--- a/src/main/java/de/thetaphi/forbiddenapis/gradle/CheckForbiddenApisExtension.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/gradle/CheckForbiddenApisExtension.java
@@ -26,6 +26,7 @@ import org.gradle.api.file.FileCollection;
  * Extension for the ForbiddenApis Gradle Task to store defaults.
  * For description of the properties refer to the {@link CheckForbiddenApis}
  * task documentation.
+ * @since 2.0
  */
 public class CheckForbiddenApisExtension {
   

--- a/src/main/java/de/thetaphi/forbiddenapis/gradle/ForbiddenApisPlugin.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/gradle/ForbiddenApisPlugin.java
@@ -32,8 +32,8 @@ import org.gradle.api.Project;
 import org.gradle.api.plugins.PluginInstantiationException;
 
 /**
- * Forbiddenapis Gradle Plugin
- * @since 1.9
+ * Forbiddenapis Gradle Plugin (requires at least Gradle 2.3)
+ * @since 2.0
  */
 public class ForbiddenApisPlugin implements Plugin<Project> {
   


### PR DESCRIPTION
This PR will change the minimum Gradle version to 2.3: This is needed for the new ParallelizableTask annotation.