### PR TITLE
Add support for signature file URLs

### DIFF
--- a/src/main/java/de/thetaphi/forbiddenapis/Checker.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/Checker.java
@@ -405,6 +405,11 @@ public final class Checker implements RelatedClassLookup {
     parseSignaturesFile(in, false);
   }
   
+  /** Reads a list of API signatures from the given URL. */
+  public final void parseSignaturesFile(URL url) throws IOException,ParseException {
+    parseSignaturesFile(url.openStream());
+  }
+  
   /** Reads a list of API signatures from the given file. */
   public final void parseSignaturesFile(File f) throws IOException,ParseException {
     parseSignaturesFile(new FileInputStream(f));

--- a/src/main/java/de/thetaphi/forbiddenapis/gradle/CheckForbiddenApis.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/gradle/CheckForbiddenApis.java
@@ -177,7 +177,7 @@ public class CheckForbiddenApis extends DefaultTask implements PatternFilterable
     return data.signaturesURLs;
   }
 
-  /** @see #getSignaturesFiles */
+  /** @see #getSignaturesURLs */
   public void setSignaturesURLs(List<URL> signaturesURLs) {
     data.signaturesURLs = signaturesURLs;
   }

--- a/src/main/java/de/thetaphi/forbiddenapis/gradle/CheckForbiddenApis.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/gradle/CheckForbiddenApis.java
@@ -164,6 +164,25 @@ public class CheckForbiddenApis extends DefaultTask implements PatternFilterable
   }
 
   /**
+   * A list of references to URLs, which contain signatures and comments for forbidden API calls.
+   * The signatures are resolved against {@link #getClasspath()}.
+   * <p>
+   * This property is useful to refer to resources in plugin classpath, e.g., using
+   * {@link Class#getResource(String)}. It is not useful for general gradle builds. Especially,
+   * don't use it to refer to resources on foreign servers!
+   */
+  @Input
+  @Optional
+  public List<URL> getSignaturesURLs() {
+    return data.signaturesURLs;
+  }
+
+  /** @see #getSignaturesFiles */
+  public void setSignaturesURLs(List<URL> signaturesURLs) {
+    data.signaturesURLs = signaturesURLs;
+  }
+
+  /**
    * Gives multiple API signatures that are joined with newlines and
    * parsed like a single {@link #getSignaturesFiles()}.
    * The signatures are resolved against {@link #getClasspath()}.
@@ -504,6 +523,11 @@ public class CheckForbiddenApis extends DefaultTask implements PatternFilterable
         if (signaturesFiles != null) for (final File f : signaturesFiles) {
           log.info("Reading API signatures: " + f);
           checker.parseSignaturesFile(f);
+        }
+        final List<URL> signaturesURLs = getSignaturesURLs();
+        if (signaturesURLs != null) for (final URL url : signaturesURLs) {
+          log.info("Reading API signatures: " + url);
+          checker.parseSignaturesFile(url);
         }
       } catch (IOException ioe) {
         throw new ResourceException("IO problem while reading files with API signatures.", ioe);

--- a/src/main/java/de/thetaphi/forbiddenapis/gradle/CheckForbiddenApis.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/gradle/CheckForbiddenApis.java
@@ -34,6 +34,7 @@ import java.util.Set;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
+import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
@@ -173,6 +174,7 @@ public class CheckForbiddenApis extends DefaultTask implements PatternFilterable
    */
   @Input
   @Optional
+  @Incubating
   public List<URL> getSignaturesURLs() {
     return data.signaturesURLs;
   }

--- a/src/main/java/de/thetaphi/forbiddenapis/gradle/CheckForbiddenApisExtension.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/gradle/CheckForbiddenApisExtension.java
@@ -16,6 +16,7 @@ package de.thetaphi.forbiddenapis.gradle;
  * limitations under the License.
  */
 
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -33,6 +34,7 @@ public class CheckForbiddenApisExtension {
   /** Fields used for the convention mapping, keep up-to-date with class members! */
   static final List<String> PROPS = Arrays.asList(
     "signaturesFiles",
+    "signaturesURLs",
     "signatures",
     "bundledSignatures",
     "suppressAnnotations",
@@ -44,6 +46,7 @@ public class CheckForbiddenApisExtension {
   );
   
   public FileCollection signaturesFiles;
+  public List<URL> signaturesURLs = new ArrayList<URL>();
   public List<String> signatures = new ArrayList<String>(),
     bundledSignatures = new ArrayList<String>(),
     suppressAnnotations = new ArrayList<String>();


### PR DESCRIPTION
In the gradle build it may be useful to use URLs to signature files (e.g. when building a plugin). This allows this feature