### PR TITLE
Allow arbitrary Ant resources as signatures

### DIFF
--- a/src/main/docs/ant-task.html
+++ b/src/main/docs/ant-task.html
@@ -165,7 +165,8 @@ so you don't need to add this as include attribute to those collections.</p>
 
 <ul>
   <li>Use <code>bundledSignatures</code> element to pass a <a href="bundled-signatures.html">built-in signatures</a> file, e.g. <code>&lt;bundledsignatures name=&quot;jdk-unsafe-1.7&quot;/&gt;</code></li>
-  <li>Use <code>signaturesFileSet</code>, <code>signaturesFileList</code>, <code>signaturesFile</code> elements to pass in collections of signatures files. Those elements behave like the corresponding standard Ant types.</li>
+  <li>Use <code>signaturesResources</code> element to wrap any valid <a href="https://ant.apache.org/manual/Types/resources.html">Ant resource</a> type (filesets,..).</li>
+  <li>Alternatively, use <code>signaturesFileSet</code>, <code>signaturesFileList</code>, <code>signaturesFile</code> elements to pass in collections of signatures files. Those elements behave like the corresponding standard Ant types.</li>
   <li>Place signatures as plain text (use CDATA sections) inside the <code>forbiddenapis</code> element.</li>
 </ul>
 

--- a/src/test/antunit/TestFileSignatures.xml
+++ b/src/test/antunit/TestFileSignatures.xml
@@ -57,4 +57,18 @@
     <au:assertLogContains level="error" text="java.lang.String#substring(int,int) [You are crazy that you disallow substrings]"/> 
   </target>
   
+  <target name="testGeneralResources">
+    <au:expectfailure expectedMessage="Check for forbidden API calls failed, see log">
+      <forbiddenapis classpathref="path.all">
+        <fileset refid="main.classes"/>
+        <signaturesResources>
+          <file file="signatures1.txt"/>
+          <string>java.util.Locale#ENGLISH @ We are speaking chinese here!</string>
+        </signaturesResources>
+      </forbiddenapis>
+    </au:expectfailure>
+    <au:assertLogContains level="error" text="java.lang.String#substring(int,int) [You are crazy that you disallow substrings]"/> 
+    <au:assertLogContains level="error" text="java.util.Locale#ENGLISH [We are speaking chinese here!]"/> 
+  </target>
+  
 </project>


### PR DESCRIPTION
This allows to add arbitrary resources as signatures to the Ant task. Just put any signature resources inside the element: ```<signaturesResources></signaturesResources>```

This now allows to place anything inside that can be converted to an InputStream (URLs,...). The other inner elements are still supported, but may be deprecated in the future.