### PR TITLE
Add support for new Java version style "6.0" instead of "1.6"

### DIFF
--- a/src/main/java/de/thetaphi/forbiddenapis/Checker.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/Checker.java
@@ -401,6 +401,10 @@ public final class Checker implements RelatedClassLookup {
     InputStream in = Checker.class.getResourceAsStream("signatures/" + name + ".txt");
     // automatically expand the compiler version in here (for jdk-* signatures without version):
     if (in == null && jdkTargetVersion != null && name.startsWith("jdk-") && !name.matches(".*?\\-\\d\\.\\d")) {
+      // convert the "new" version number "major.0" to old-style "1.major" (as this matches our resources):
+      if (!jdkTargetVersion.startsWith("1.") && jdkTargetVersion.matches("\\d\\.0")) {
+        jdkTargetVersion = "1." + jdkTargetVersion.substring(0, 1);
+      }
       name = name + "-" + jdkTargetVersion;
       in = Checker.class.getResourceAsStream("signatures/" + name + ".txt");
     }

--- a/src/test/antunit/TestMavenMojo.xml
+++ b/src/test/antunit/TestMavenMojo.xml
@@ -29,8 +29,19 @@
       <syspropertyset refid="injected-properties"/>
     </artifact:mvn>
     <au:assertLogContains text=" 0 error(s)."/> 
-    <au:assertLogContains text="Reading bundled API signatures: jdk-deprecated"/> 
-    <au:assertLogContains text="Reading bundled API signatures: jdk-unsafe"/> 
+    <au:assertLogContains text="Reading bundled API signatures: jdk-deprecated-${jdk.version}"/> 
+    <au:assertLogContains text="Reading bundled API signatures: jdk-unsafe-${jdk.version}"/> 
+  </target>
+  
+  <target name="testMyselfMaven2NewJavaVersion">
+    <artifact:mvn pom="${antunit.fake-pom}" mavenVersion="${maven.version}" failonerror="true" fork="${maven.fork}">
+      <arg value="${groupId}:${artifactId}:${version}:check"/>
+      <syspropertyset refid="injected-properties"/>
+      <sysproperty key="maven.compiler.target" value="6.0"/>
+    </artifact:mvn>
+    <au:assertLogContains text=" 0 error(s)."/> 
+    <au:assertLogContains text="Reading bundled API signatures: jdk-deprecated-1.6"/> 
+    <au:assertLogContains text="Reading bundled API signatures: jdk-unsafe-1.6"/> 
   </target>
   
   <target name="testInlineSignaturesMaven2">
@@ -105,8 +116,8 @@
       <syspropertyset refid="injected-properties"/>
     </artifact:mvn>
     <au:assertLogContains text=" 0 error(s)."/> 
-    <au:assertLogContains text="Reading bundled API signatures: jdk-deprecated"/> 
-    <au:assertLogContains text="Reading bundled API signatures: jdk-unsafe"/> 
+    <au:assertLogContains text="Reading bundled API signatures: jdk-deprecated-${jdk.version}"/> 
+    <au:assertLogContains text="Reading bundled API signatures: jdk-unsafe-${jdk.version}"/> 
   </target>
 
   <target name="testSigArtifacts-Maven2">


### PR DESCRIPTION
With Javac, you can currently also use the "new" version style "6.0" instead of "1.6". Currenbtly this would lead to a parse failure when loading bundled signatures.

This patch adds support for the new version style (which will get the default from Java 9+). Internally the new version numbers are rewritten to old format.