### PR TITLE
Add initial support for new Java 9 class file format (JDK-8148785)

### DIFF
--- a/src/main/java/de/thetaphi/forbiddenapis/Checker.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/Checker.java
@@ -245,7 +245,7 @@ public final class Checker implements RelatedClassLookup, Constants {
     }
     
     try {
-      return new ClassSignature(new ClassReader(in), AsmUtils.isRuntimeModule(moduleName), false);
+      return new ClassSignature(AsmUtils.readAndPatchClass(in), AsmUtils.isRuntimeModule(moduleName), false);
     } finally {
       in.close();
     }
@@ -297,7 +297,7 @@ public final class Checker implements RelatedClassLookup, Constants {
         final boolean isRuntimeClass = isRuntimeClass(conn);
         final InputStream in = conn.getInputStream();
         try {
-          classpathClassCache.put(clazz, c = new ClassSignature(new ClassReader(in), isRuntimeClass, false));
+          classpathClassCache.put(clazz, c = new ClassSignature(AsmUtils.readAndPatchClass(in), isRuntimeClass, false));
         } finally {
           in.close();
         }
@@ -528,7 +528,7 @@ public final class Checker implements RelatedClassLookup, Constants {
   public void addClassToCheck(final InputStream in) throws IOException {
     final ClassReader reader;
     try {
-      reader = new ClassReader(in);
+      reader = AsmUtils.readAndPatchClass(in);
     } finally {
       in.close();
     }

--- a/src/tools/java/de/thetaphi/forbiddenapis/DeprecatedGen.java
+++ b/src/tools/java/de/thetaphi/forbiddenapis/DeprecatedGen.java
@@ -71,7 +71,7 @@ public abstract class DeprecatedGen<Input> implements Opcodes {
   protected void parseClass(InputStream in) throws IOException {
     final ClassReader reader;
     try {
-      reader = new ClassReader(in);
+      reader = AsmUtils.readAndPatchClass(in);
     } catch (IllegalArgumentException iae) {
       // unfortunately the ASM IAE has no message, so add good info!
       throw new IllegalArgumentException("The class file format of your runtime seems to be too recent to be parsed by ASM (may need to be upgraded).");


### PR DESCRIPTION
Java 9 will add a new bytecode version (53). This patch adds support for it (similar to what we have done in Java 8). Once next version of ASM is out, we can remove the PushBackInputStream!