### PR TITLE
Add bundled signature for Apache Commons IO 2.6

### DIFF
--- a/src/main/resources/de/thetaphi/forbiddenapis/signatures/commons-io-unsafe-2.6.txt
+++ b/src/main/resources/de/thetaphi/forbiddenapis/signatures/commons-io-unsafe-2.6.txt
@@ -1,0 +1,17 @@
+# (C) Copyright Uwe Schindler (Generics Policeman) and others.
+# Parts of this work are licensed to the Apache Software Foundation (ASF)
+# under one or more contributor license agreements.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@includeBundled commons-io-unsafe-2.5


### PR DESCRIPTION
This PR adds bundled signatures for the recently released [Apache Commons IO 2.6](https://commons.apache.org/proper/commons-io/changes-report.html#a2.6).

It's a bit lazy because it simply includes the previous bundled signatures, though. 😉 