### PR TITLE
Do not emit 'and 0 more' in ignored signatures message

### DIFF
--- a/src/main/java/de/thetaphi/forbiddenapis/Signatures.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/Signatures.java
@@ -221,7 +221,10 @@ public final class Signatures implements Constants {
       sb.append(count == 0 ? "  " : ", ").append(s);
       count++;
       if (sb.length() >= 70) {
-        sb.append(",... (and ").append(missingClasses.size() - count).append(" more).");
+        int remaining = missingClasses.size() - count;
+        if (remaining > 0) {
+          sb.append(",... (and ").append(remaining).append(" more).");
+        }
         break;
       }
     }


### PR DESCRIPTION
The warning code can emit 'and 0 more', as in:
```
build	19-Oct-2018 10:13:22	[WARNING] Some signatures were ignored because the following classes were not found on classpath:
build	19-Oct-2018 10:13:22	[WARNING]   com.google.common.collect.Lists, com.google.common.collect.Maps, com.google.inject.Guice,... (and 0 more).
```