### PR TITLE
Use https for repo.gradle.org

### DIFF
--- a/ivy-settings.xml
+++ b/ivy-settings.xml
@@ -23,7 +23,7 @@
   <include url="${ivy.default.settings.dir}/ivysettings-main-chain.xml"/>
   
   <resolvers>
-    <ibiblio name="gradle" root="http://repo.gradle.org/gradle/libs-releases-local" m2compatible="true" />
+    <ibiblio name="gradle" root="https://repo.gradle.org/gradle/libs-releases-local" m2compatible="true" />
     <ibiblio name="maven-http-backup" root="${ivy.maven-central.backup}" m2compatible="true" />
     <chain name="default" returnFirst="true" checkmodified="true" changingPattern=".*SNAPSHOT">
       <resolver ref="main"/>


### PR DESCRIPTION
This fixes downloading of gradle resources, since gradle.org does not allow http anymore