### PR TITLE
Hides the warning if the classes directory/fileset is missing

### DIFF
--- a/src/main/java/de/thetaphi/forbiddenapis/ant/AntTask.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/ant/AntTask.java
@@ -83,7 +83,7 @@ public class AntTask extends Task implements Constants {
       @Override
       public void warn(String msg) {
         // ANT has no real log levels printed, so prefix with "WARNING":
-        log("WARNING: " + msg, Project.MSG_WARN);
+        log("WARNING: ".concat(msg), Project.MSG_WARN);
       }
       
       @Override
@@ -188,8 +188,7 @@ public class AntTask extends Task implements Constants {
         }
         if (!foundClass) {
           if (ignoreEmptyFileset) {
-            log.warn("There is no <fileset/> or other resource collection given, or the collection does not contain any class files to check.");
-            log.info("Scanned 0 class files.");
+            log.info("Resource collection of class files is empty. Scanned 0 class files.");
             return;
           } else {
             throw new BuildException("There is no <fileset/> or other resource collection given, or the collection does not contain any class files to check.");
@@ -341,7 +340,7 @@ public class AntTask extends Task implements Constants {
     this.restrictClassFilename = restrictClassFilename;
   }
 
-  /** Ignore empty fileset/resource collection and print a warning instead.
+  /** Ignore empty fileset/resource collection.
    * Defaults to {@code false}.
    */
   public void setIgnoreEmptyFileSet(boolean ignoreEmptyFileset) {

--- a/src/main/java/de/thetaphi/forbiddenapis/maven/AbstractCheckMojo.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/maven/AbstractCheckMojo.java
@@ -336,7 +336,7 @@ public abstract class AbstractCheckMojo extends AbstractMojo implements Constant
       log.info("Scanning for classes to check...");
       final File classesDirectory = getClassesDirectory();
       if (!classesDirectory.exists()) {
-        log.warn("Classes directory does not exist, forbiddenapis check skipped: " + classesDirectory);
+        log.info("Classes directory does not exist, forbiddenapis check skipped: " + classesDirectory);
         return;
       }
       final DirectoryScanner ds = new DirectoryScanner();
@@ -348,7 +348,7 @@ public abstract class AbstractCheckMojo extends AbstractMojo implements Constant
       ds.scan();
       final String[] files = ds.getIncludedFiles();
       if (files.length == 0) {
-        log.warn(String.format(Locale.ENGLISH,
+        log.info(String.format(Locale.ENGLISH,
           "No classes found in '%s' (includes=%s, excludes=%s), forbiddenapis check skipped.",
           classesDirectory.toString(), Arrays.toString(includes), Arrays.toString(excludes)));
         return;


### PR DESCRIPTION
Relates to #83: Make the behaviour of the Maven task in line with other tasks (like compile or Javadocs) and don't display a warning if no input files exist. In Gradle the task is automatically suppressed due to @SkipIfEmpty.

Also change the Ant task to just log with INFO.