### PR TITLE
Move some initialization steps (especially reflection) to Plugin's static initialization

### DIFF
--- a/src/main/resources/de/thetaphi/forbiddenapis/gradle/plugin-init.groovy
+++ b/src/main/resources/de/thetaphi/forbiddenapis/gradle/plugin-init.groovy
@@ -20,16 +20,10 @@ import java.lang.reflect.Modifier;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.util.GradleVersion;
 
-final boolean TASK_AVOIDANCE_AVAILABLE = GradleVersion.current() >= GradleVersion.version("4.9");
-
 project.plugins.apply(JavaBasePlugin.class);
 
 // create Extension for defaults:
 def extension = project.extensions.create(FORBIDDEN_APIS_EXTENSION_NAME, CheckForbiddenApisExtension.class, project);
-def extensionProps = CheckForbiddenApisExtension.class.declaredFields.findAll{ f -> 
-  int mods = f.modifiers;
-  return Modifier.isPublic(mods) && !f.synthetic && !Modifier.isStatic(mods)
-}*.name;
 
 // Create a convenience task for all checks (this does not conflict with extension, as it has higher priority in DSL):
 def forbiddenTask = TASK_AVOIDANCE_AVAILABLE ? project.tasks.register(FORBIDDEN_APIS_TASK_NAME) : project.tasks.create(FORBIDDEN_APIS_TASK_NAME)
@@ -48,7 +42,7 @@ project.sourceSets.all{ sourceSet ->
     dependsOn(sourceSet.output);
     outputs.upToDateWhen { true }
     conventionMapping.with{
-      extensionProps.each{ key ->
+      FORBIDDEN_APIS_EXTENSION_PROPS.each{ key ->
         map(key, { extension[key] });
       }
       classesDirs = { sourceSet.output.hasProperty('classesDirs') ? sourceSet.output.classesDirs : project.files(sourceSet.output.classesDir) }


### PR DESCRIPTION
This PR is trying to remove more stuff from the apply phase of plugin (which applies per project) to the JVM initialization (when forbiddenapis is loaded). So the runtime cost for each project is hopefully reduced. This includes:
- reflection of the extension properties (this is just creating a list of property names used to populate conventionmapping) when the task is actually created. Previously this was done on apply of plugin to project.
- initialization of task avoidance flag

See https://github.com/elastic/elasticsearch/issues/56330