### PR TITLE
Add support for maven.compiler.release/testRelease

### DIFF
--- a/src/main/java/de/thetaphi/forbiddenapis/maven/AbstractCheckMojo.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/maven/AbstractCheckMojo.java
@@ -186,6 +186,14 @@ public abstract class AbstractCheckMojo extends AbstractMojo implements Constant
   private String targetVersion;
 
   /**
+   * The default compiler release version used to expand references to bundled JDK signatures.
+   * E.g., if you use "jdk-deprecated", it will expand to this version.
+   * This setting should be identical to the release version used in the compiler plugin starting with Java 9.
+   */
+  @Parameter(required = false, defaultValue = "${maven.compiler.release}")
+  private String releaseVersion;
+
+  /**
    * List of patterns matching all class files to be parsed from the classesDirectory.
    * Can be changed to e.g. exclude several files (using excludes).
    * The default is a single include with pattern '**&#47;*.class'
@@ -248,7 +256,7 @@ public abstract class AbstractCheckMojo extends AbstractMojo implements Constant
 
   /** gets overridden for test, because it uses testTargetVersion as optional name to override */
   protected String getTargetVersion() {
-    return targetVersion;
+    return (releaseVersion != null) ? releaseVersion : targetVersion;
   }
   
   private File resolveSignaturesArtifact(SignaturesArtifact signaturesArtifact) throws ArtifactResolutionException, ArtifactNotFoundException {
@@ -385,7 +393,8 @@ public abstract class AbstractCheckMojo extends AbstractMojo implements Constant
           String targetVersion = getTargetVersion();
           if ("".equals(targetVersion)) targetVersion = null;
           if (targetVersion == null) {
-            log.warn("The 'targetVersion' parameter or '${maven.compiler.target}' property is missing. " +
+            log.warn("The 'targetVersion' and 'targetRelease' parameters or " +
+              "'${maven.compiler.target}' and '${maven.compiler.release}' properties are missing. " +
               "Trying to read bundled JDK signatures without compiler target. " +
               "You have to explicitly specify the version in the resource name.");
           }

--- a/src/main/java/de/thetaphi/forbiddenapis/maven/TestCheckMojo.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/maven/TestCheckMojo.java
@@ -59,6 +59,16 @@ public final class TestCheckMojo extends AbstractCheckMojo {
   @Parameter(required = false, defaultValue = "${maven.compiler.testTarget}")
   private String testTargetVersion;
 
+  /**
+   * The default compiler release version used to expand references to bundled JDK signatures.
+   * This setting falls back to "targetVersion" if undefined. This can be used to override
+   * the release version solely used for tests.
+   * E.g., if you use "jdk-deprecated", it will expand to this version.
+   * This setting should be identical to the release version used in the compiler plugin.
+   */
+  @Parameter(required = false, defaultValue = "${maven.compiler.testRelease}")
+  private String testReleaseVersion;
+
   @Override
   protected List<String> getClassPathElements() {
     return this.classpathElements;
@@ -71,7 +81,8 @@ public final class TestCheckMojo extends AbstractCheckMojo {
   
   @Override
   protected String getTargetVersion() {
-    return (testTargetVersion != null) ? testTargetVersion : super.getTargetVersion();
+    return (testReleaseVersion != null) ?
+            testReleaseVersion : (testTargetVersion != null) ? testTargetVersion : super.getTargetVersion();
   }
   
 }


### PR DESCRIPTION
Add support for the `maven.compiler.release` and `maven.compiler.testRelease` properties which can be used to since Java 9 to provide the `--release` argument for the Java compiler.

The release version (`releaseVersion`, `testReleaseVersion`) is being used over the target version (`targetVersion`, `testTargetVersion`) if it was defined, otherwise the target version is being used.

* https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#release
* https://maven.apache.org/plugins/maven-compiler-plugin/testCompile-mojo.html#testRelease
* https://docs.oracle.com/javase/9/tools/javac.htm#GUID-AEEC9F07-CB49-4E96-8BC7-BCC2C7F725C9__GUID-D343F6B4-3FDD-43A8-AD24-43DD70214471