### PR TITLE
Fix #168: Commons-IO signatures fails to resolve in commons-io v2.7

### DIFF
--- a/src/main/resources/de/thetaphi/forbiddenapis/signatures/commons-io-unsafe-1.0.txt
+++ b/src/main/resources/de/thetaphi/forbiddenapis/signatures/commons-io-unsafe-1.0.txt
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-@ignoreUnresolvable
-
 @defaultMessage Uses default charset
 org.apache.commons.io.CopyUtils#copy(byte[],java.io.Writer)
 org.apache.commons.io.CopyUtils#copy(java.io.InputStream,java.io.Writer)
@@ -25,4 +23,6 @@ org.apache.commons.io.IOUtils#toByteArray(java.io.Reader)
 org.apache.commons.io.IOUtils#toByteArray(java.lang.String)
 org.apache.commons.io.IOUtils#toString(byte[])
 org.apache.commons.io.IOUtils#toString(java.io.InputStream)
+
+@ignoreUnresolvable
 org.apache.commons.io.output.ByteArrayOutputStream#toString()

--- a/src/main/resources/de/thetaphi/forbiddenapis/signatures/commons-io-unsafe-2.7.txt
+++ b/src/main/resources/de/thetaphi/forbiddenapis/signatures/commons-io-unsafe-2.7.txt
@@ -14,15 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-@ignoreUnresolvable
+@includeBundled commons-io-unsafe-2.6
 
 @defaultMessage Uses default charset
-org.apache.commons.io.CopyUtils#copy(byte[],java.io.Writer)
-org.apache.commons.io.CopyUtils#copy(java.io.InputStream,java.io.Writer)
-org.apache.commons.io.CopyUtils#copy(java.io.Reader,java.io.OutputStream)
-org.apache.commons.io.CopyUtils#copy(java.lang.String,java.io.OutputStream)
-org.apache.commons.io.IOUtils#toByteArray(java.io.Reader)
-org.apache.commons.io.IOUtils#toByteArray(java.lang.String)
-org.apache.commons.io.IOUtils#toString(byte[])
-org.apache.commons.io.IOUtils#toString(java.io.InputStream)
-org.apache.commons.io.output.ByteArrayOutputStream#toString()
+org.apache.commons.io.output.AbstractByteArrayOutputStream#toString()


### PR DESCRIPTION
This is caused by an incompatible change  in commons-io 2.7 (`ByteBufferOutputStream` was refactored to have a new base class `AbstractByteBufferOutputStream`); This also adds signatures for version 2.7.

TODO: Scan for other API differences (new methods) in 2.7 vs. 2.6