### PR TITLE
Add better reporting if ASM fails to parse a class with an unspecified RuntimeException

### DIFF
--- a/src/main/java/de/thetaphi/forbiddenapis/AsmUtils.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/AsmUtils.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import org.objectweb.asm.ClassReader;
@@ -180,6 +181,14 @@ public final class AsmUtils {
     final byte[] bytecode = readStream(in);
     if (false) patchClassMajorVersion(bytecode, Opcodes.V15 + 1, Opcodes.V15);
     return new ClassReader(bytecode);
+  }
+  
+  /** Returns true, if the given {@link RuntimeException} was caused by ASM's ClassReader */
+  public static boolean isExceptionInAsmClassReader(RuntimeException re) {
+    // Because of javac bugs some class files are broken and cause RuntimeExceptions like AIOOBE
+    // We analyze stack trace if this is caused by ASM's ClassReader and not our code:
+    final StackTraceElement[] stack = re.getStackTrace();
+    return stack.length > 0 && Objects.equals(ClassReader.class.getName(), stack[0].getClassName());
   }
 
 }

--- a/src/main/java/de/thetaphi/forbiddenapis/RelatedClassLoadingException.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/RelatedClassLoadingException.java
@@ -33,6 +33,11 @@ final class RelatedClassLoadingException extends RuntimeException {
     this.className = className;
   }
   
+  public RelatedClassLoadingException(RuntimeException e, String className) {
+    super(e);
+    this.className = className;
+  }
+  
   public Exception getException() {
     return (Exception) getCause();
   }


### PR DESCRIPTION
This PR adds a detailed error message when a broken class file occurs.

This closes #173 