### PR TITLE
Fix wrong signature: `DateTimeFormatterBuilder#toFormatter()` is using default locale

### DIFF
--- a/src/main/resources/de/thetaphi/forbiddenapis/signatures/jdk-unsafe-1.8.txt
+++ b/src/main/resources/de/thetaphi/forbiddenapis/signatures/jdk-unsafe-1.8.txt
@@ -37,7 +37,7 @@ java.time.chrono.MinguoDate#now()
 java.time.chrono.ThaiBuddhistDate#now()
 
 @defaultMessage Uses default locale
-java.time.format.DateTimeFormatterBuilder#toFormatter(java.time.format.ResolverStyle,java.time.chrono.Chronology)
+java.time.format.DateTimeFormatterBuilder#toFormatter()
 java.time.format.DateTimeFormatter#ofLocalizedDate(java.time.format.FormatStyle)
 java.time.format.DateTimeFormatter#ofLocalizedDateTime(java.time.format.FormatStyle,java.time.format.FormatStyle)
 java.time.format.DateTimeFormatter#ofLocalizedDateTime(java.time.format.FormatStyle)


### PR DESCRIPTION
The original commit https://github.com/policeman-tools/forbidden-apis/commit/a3ceb3e6987dbf05317e633b264f33cfa7c5961b added a package private method from inside the JDK to the forbidden api list, but the actual public one calling those one was forgotten.

This adds the broken method. This may report more failures in code out there, so we need to put it into release note.