### PR TITLE
Improve build avoidance by ignoring ABI-compatible changes

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -16,7 +16,7 @@
 -->
 <!DOCTYPE ivy-module [
   <!ENTITY maven.version "2.0">
-  <!ENTITY gradle.version "3.2">
+  <!ENTITY gradle.version "3.4">
   <!ENTITY asm.version "9.2">
   <!ENTITY jarjar.asm.version "5.2">
 ]>

--- a/src/main/java/de/thetaphi/forbiddenapis/gradle/CheckForbiddenApis.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/gradle/CheckForbiddenApis.java
@@ -39,7 +39,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.specs.Spec;
-import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
@@ -149,7 +149,7 @@ public class CheckForbiddenApis extends DefaultTask implements PatternFilterable
    * Defaults to current sourseSet's compile classpath.
    */
   @InputFiles
-  @Classpath
+  @CompileClasspath
   public FileCollection getClasspath() {
     return classpath;
   }

--- a/src/main/java/de/thetaphi/forbiddenapis/gradle/CheckForbiddenApis.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/gradle/CheckForbiddenApis.java
@@ -148,7 +148,6 @@ public class CheckForbiddenApis extends DefaultTask implements PatternFilterable
    * A {@link FileCollection} used to configure the classpath.
    * Defaults to current sourseSet's compile classpath.
    */
-  @InputFiles
   @CompileClasspath
   public FileCollection getClasspath() {
     return classpath;


### PR DESCRIPTION
This pull request improves build avoidance (increases the likelyhood that tasks are UP-TO-DATE) by leveraging Gradle's _compile_ classpath input normalization. For the purposes of checking for forbidden APIs, we don't much care about non-API changes in the upstream classpath. That is, if an ABI-compatible change is made to a class on our classpath (say, a single line change to a method body) it doesn't affect the outcome of this task. This avoid having to rerun this check when changes are made to upstream dependencies that don't change the compile classpath.

Since the `@CompileClasspath` annotation was introduced in Gradle 3.4, that would mean the minimum compatible Gradle version would increase from 3.2 to 3.4.