### PR TITLE
Wildcard method signatures

### DIFF
--- a/src/main/docs/signatures-syntax.html
+++ b/src/main/docs/signatures-syntax.html
@@ -41,9 +41,10 @@ of signatures are supported:</p>
   <li><em>A field of a class:</em> <code>package.Class#fieldName</code></li>
   <li><em>A method signature:</em> It consists of a binary class name, followed by <code>#</code>
   and a method name including method parameters: <code>java.lang.String#concat(java.lang.String)</code>
-  &ndash; All method parameters need to use fully qualified class names!
-  To refer to instance constructors, use the method name <code>&lt;init&gt;</code>,
-  e.g. <code>java.lang.Integer#&lt;init&gt;(int)</code>.</li>
+  &ndash; All method parameters need to use fully qualified class names! Instead of
+  method parameters, the special wildcard string <code>**</code> may be used to add all variants
+  of a method, regardless of their parameter types. To refer to instance constructors, use the
+  method name <code>&lt;init&gt;</code>, e.g. <code>java.lang.Integer#&lt;init&gt;(int)</code>.</li>
 </ul>
 
 <p>The error message displayed when the signature matches can be given at the end of each

--- a/src/main/java/de/thetaphi/forbiddenapis/Signatures.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/Signatures.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.Method;
@@ -48,6 +49,9 @@ public final class Signatures implements Constants {
   private static final String DEFAULT_MESSAGE_PREFIX = "@defaultMessage ";
   private static final String IGNORE_UNRESOLVABLE_LINE = "@ignoreUnresolvable";
   private static final String IGNORE_MISSING_CLASSES_LINE = "@ignoreMissingClasses";
+  private static final String WILDCARD_ARGS = "**";
+  private static final Pattern PATTERN_WILDCARD_ARGS = Pattern.compile(String.format(Locale.ROOT, "%s\\s*%s\\s*%s",
+      Pattern.quote("("), Pattern.quote(WILDCARD_ARGS), Pattern.quote(")")));
 
   private static enum UnresolvableReporting {
     FAIL(true) {
@@ -125,7 +129,6 @@ public final class Signatures implements Constants {
     final String clazz, field, signature;
     String message = null;
     final Method method;
-    boolean ignoreMethodArguments = false;
     int p = line.indexOf('@');
     if (p >= 0) {
       signature = line.substring(0, p).trim();
@@ -140,23 +143,22 @@ public final class Signatures implements Constants {
     p = signature.indexOf('#');
     if (p >= 0) {
       clazz = signature.substring(0, p);
-      String methodOrField = signature.substring(p + 1);
+      final String methodOrField = signature.substring(p + 1);
       p = methodOrField.indexOf('(');
       if (p >= 0) {
-        String s = methodOrField;
-        if (methodOrField.substring(p).equals("(**)")) {
-          // We will ignore method arguments and match everything with the same name
-          s = signature.substring(0, p) + "()";
-          ignoreMethodArguments = true;
-        }
         if (p == 0) {
           throw new ParseException("Invalid method signature (method name missing): " + signature);
         }
-        // we ignore the return type, its just to match easier (so return type is void):
-        try {
-          method = Method.getMethod("void " + s, true);
-        } catch (IllegalArgumentException iae) {
-          throw new ParseException("Invalid method signature: " + signature);
+        if (PATTERN_WILDCARD_ARGS.matcher(methodOrField.substring(p)).matches()) {
+          // we create a method instance with the special descriptor string "**", which gets detected later:
+          method = new Method(methodOrField.substring(0, p).trim(), WILDCARD_ARGS);
+        } else {
+          // we ignore the return type, it just allows the parser to succeed (so return type is void):
+          try {
+            method = Method.getMethod("void ".concat(methodOrField), true);
+          } catch (IllegalArgumentException iae) {
+            throw new ParseException("Invalid method signature: " + signature);
+          }
         }
         field = null;
       } else {
@@ -199,7 +201,8 @@ public final class Signatures implements Constants {
         // list all methods with this signature:
         boolean found = false;
         for (final Method m : c.methods) {
-          if (m.getName().equals(method.getName()) && (ignoreMethodArguments || Arrays.equals(m.getArgumentTypes(), method.getArgumentTypes()))) {
+          if (m.getName().equals(method.getName()) && 
+              (WILDCARD_ARGS.equals(method.getDescriptor()) || Arrays.equals(m.getArgumentTypes(), method.getArgumentTypes()))) {
             found = true;
             signatures.put(getKey(c.className, m), printout);
             // don't break when found, as there may be more covariant overrides!

--- a/src/test/antunit/TestInlineSignatures.xml
+++ b/src/test/antunit/TestInlineSignatures.xml
@@ -67,6 +67,16 @@
     <au:assertLogContains level="error" text="java.lang.String#substring(int,int) [You are crazy that you disallow substrings]"/> 
   </target>
   
+  <target name="testForbiddenWildcardMethodWithMessage">
+    <au:expectfailure expectedMessage="Check for forbidden API calls failed, see log">
+      <forbiddenapis classpathref="path.all">
+        <fileset refid="main.classes"/>
+        java.lang.String#substring(**) @ You are crazy that you disallow all substrings
+      </forbiddenapis>
+    </au:expectfailure>
+    <au:assertLogContains level="error" text="java.lang.String#substring(**) [You are crazy that you disallow all substrings]"/> 
+  </target>
+  
   <target name="testForbiddenFieldWithMessage">
     <au:expectfailure expectedMessage="Check for forbidden API calls failed, see log">
       <forbiddenapis classpathref="path.all">

--- a/src/test/java/de/thetaphi/forbiddenapis/CheckerSetupTest.java
+++ b/src/test/java/de/thetaphi/forbiddenapis/CheckerSetupTest.java
@@ -89,6 +89,62 @@ public final class CheckerSetupTest {
   }
   
   @Test
+  public void testMethodSignatureWS() throws Exception {
+    checker.parseSignaturesString("java.lang.Object#toString( ) @ Foobar");
+    assertEquals(Collections.singletonMap(Signatures.getKey("java/lang/Object", new Method("toString", "()Ljava/lang/String;")), "java.lang.Object#toString( ) [Foobar]"),
+        forbiddenSignatures.signatures);
+    assertEquals(Collections.emptySet(), forbiddenSignatures.classPatterns);
+    assertFalse(checker.hasNoSignatures());
+    assertFalse(checker.noSignaturesFilesParsed());
+  }
+  
+  @Test
+  public void testWildcardMethodSignature() throws Exception {
+    checker.parseSignaturesString("java.lang.String#copyValueOf(**) @ Foobar");
+    
+    // For Java 7 it should at least contain those 2 signatures:
+    assertTrue(forbiddenSignatures.signatures.containsKey(Signatures.getKey("java/lang/String", new Method("copyValueOf", "([C)Ljava/lang/String;"))));
+    assertTrue(forbiddenSignatures.signatures.containsKey(Signatures.getKey("java/lang/String", new Method("copyValueOf", "([CII)Ljava/lang/String;"))));
+    
+    assertEquals(Collections.emptySet(), forbiddenSignatures.classPatterns);
+    assertFalse(checker.hasNoSignatures());
+    assertFalse(checker.noSignaturesFilesParsed());
+  }
+  
+  @Test
+  public void testWildcardMethodSignatureWS() throws Exception {
+    checker.parseSignaturesString("java.lang.String#copyValueOf( ** \t ) @ Foobar");
+    
+    // For Java 7 it should at least contain those 2 signatures:
+    assertTrue(forbiddenSignatures.signatures.containsKey(Signatures.getKey("java/lang/String", new Method("copyValueOf", "([C)Ljava/lang/String;"))));
+    assertTrue(forbiddenSignatures.signatures.containsKey(Signatures.getKey("java/lang/String", new Method("copyValueOf", "([CII)Ljava/lang/String;"))));
+    
+    assertEquals(Collections.emptySet(), forbiddenSignatures.classPatterns);
+    assertFalse(checker.hasNoSignatures());
+    assertFalse(checker.noSignaturesFilesParsed());
+  }
+  
+  @Test
+  public void testWildcardMethodSignatureNoArgs() throws Exception {
+    checker.parseSignaturesString("java.lang.Object#toString(**) @ Foobar");
+    assertEquals(Collections.singletonMap(Signatures.getKey("java/lang/Object", new Method("toString", "()Ljava/lang/String;")), "java.lang.Object#toString(**) [Foobar]"),
+        forbiddenSignatures.signatures);
+    assertEquals(Collections.emptySet(), forbiddenSignatures.classPatterns);
+    assertFalse(checker.hasNoSignatures());
+    assertFalse(checker.noSignaturesFilesParsed());
+  }
+  
+  @Test
+  public void testWildcardMethodSignatureNotExist() throws Exception {
+    try {
+      checker.parseSignaturesString("java.lang.Object#foobarNotExist(**) @ Foobar");
+      fail("Should fail to parse because method does not exist");
+    } catch (ParseException pe) {
+      assertEquals("Method not found while parsing signature: java.lang.Object#foobarNotExist(**)", pe.getMessage());
+    }
+  }
+  
+  @Test
   public void testEmptyCtor() throws Exception {
     Checker chk = new Checker(StdIoLogger.INSTANCE, ClassLoader.getSystemClassLoader());
     assertEquals(EnumSet.noneOf(Checker.Option.class), chk.options);

--- a/src/test/java/de/thetaphi/forbiddenapis/CheckerSetupTest.java
+++ b/src/test/java/de/thetaphi/forbiddenapis/CheckerSetupTest.java
@@ -90,8 +90,8 @@ public final class CheckerSetupTest {
   
   @Test
   public void testMethodSignatureWS() throws Exception {
-    checker.parseSignaturesString("java.lang.Object#toString( ) @ Foobar");
-    assertEquals(Collections.singletonMap(Signatures.getKey("java/lang/Object", new Method("toString", "()Ljava/lang/String;")), "java.lang.Object#toString( ) [Foobar]"),
+    checker.parseSignaturesString("java.lang.Object# toString\t ( ) @ Foobar");
+    assertEquals(Collections.singletonMap(Signatures.getKey("java/lang/Object", new Method("toString", "()Ljava/lang/String;")), "java.lang.Object# toString\t ( ) [Foobar]"),
         forbiddenSignatures.signatures);
     assertEquals(Collections.emptySet(), forbiddenSignatures.classPatterns);
     assertFalse(checker.hasNoSignatures());
@@ -113,7 +113,7 @@ public final class CheckerSetupTest {
   
   @Test
   public void testWildcardMethodSignatureWS() throws Exception {
-    checker.parseSignaturesString("java.lang.String#copyValueOf( ** \t ) @ Foobar");
+    checker.parseSignaturesString("java.lang.String#copyValueOf ( ** \t ) @ Foobar");
     
     // For Java 7 it should at least contain those 2 signatures:
     assertTrue(forbiddenSignatures.signatures.containsKey(Signatures.getKey("java/lang/String", new Method("copyValueOf", "([C)Ljava/lang/String;"))));


### PR DESCRIPTION
Allow specifying all methods regardless of argument types, for example:

List.of(**) would match all of the factory methods. This is useful when you want to match those methods without listing them individually and also not forbidding the entire class.

I did not see unit tests for this class, so I wasn't sure where to add testing.