### PR TITLE
Don't enforce annotations to be available, not even runtime-visible ones

### DIFF
--- a/src/main/java/de/thetaphi/forbiddenapis/ClassScanner.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/ClassScanner.java
@@ -257,8 +257,7 @@ public final class ClassScanner extends ClassVisitor implements Constants {
   
   String checkAnnotationDescriptor(Type type, boolean visible) {
     // for annotations, we don't need to look into super-classes, interfaces,...
-    // -> we just check if its disallowed or internal runtime (only if visible)!
-    return checkClassUse(type, "annotation", visible, type.getInternalName());
+    return checkClassUse(type, "annotation", false, type.getInternalName());
   }
   
   void maybeSuppressCurrentGroup(Type annotation) {


### PR DESCRIPTION
This is related to #193: The forbiddenapis checker fails on its own JAR file because the excluded runtime annotation can't be found. For annotations according to JLS we should not bail out on their existence: "Adding or removing annotations has no effect on the correct linkage of the binary representations of programs in the Java programming language."