### PR TITLE
Fix Signatures URLs added to any task are actually applied to all tasks

### DIFF
--- a/src/main/java/de/thetaphi/forbiddenapis/gradle/CheckForbiddenApis.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/gradle/CheckForbiddenApis.java
@@ -121,6 +121,11 @@ public class CheckForbiddenApis extends DefaultTask implements PatternFilterable
   private FileCollection classpath;
   private String targetCompatibility;
   
+  /** Gives access to internal data of plugin to plugin-init.groovy */
+  CheckForbiddenApisExtension internalTaskData() {
+    return data;
+  }
+
   /**
    * Directories with the class files to check.
    * Defaults to current sourseSet's output directory (Gradle 3) or output directories (Gradle 4.0+).

--- a/src/main/java/de/thetaphi/forbiddenapis/gradle/ForbiddenApisPlugin.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/gradle/ForbiddenApisPlugin.java
@@ -102,7 +102,7 @@ public class ForbiddenApisPlugin implements Plugin<Project> {
               loader.parseClass(csrc, false).asSubclass(DelegatingScript.class);
           return clazz;
         } catch (Exception e) {
-          throw new RuntimeException("Cannot compile Groovy script: " + PLUGIN_INIT_SCRIPT);
+          throw new RuntimeException("Cannot compile Groovy script: " + PLUGIN_INIT_SCRIPT, e);
         }
       }
     });

--- a/src/test/gradle/build.gradle
+++ b/src/test/gradle/build.gradle
@@ -38,6 +38,12 @@ sourceSets {
       srcDirs = [new File(forbiddenRootDir, 'src/main/java')]
     }
   }
+  main2 {
+    compileClasspath = files(forbiddenClasspath.tokenize(File.pathSeparator))
+    java {
+      srcDirs = [new File(forbiddenRootDir, 'src/main/java')]
+    }
+  }
   test {
     compileClasspath = files(forbiddenTestClasspath.tokenize(File.pathSeparator))
     java {
@@ -53,6 +59,10 @@ forbiddenApis {
 }
 
 forbiddenApisMain {
+  bundledSignatures.add('jdk-internal')
+}
+
+forbiddenApisMain2 {
   bundledSignatures += 'jdk-system-out'
 }
 


### PR DESCRIPTION
I finally found a solution to fix #203. I studied other old plugins and the trick is the following: Instead of returing a new instance in the convention, have some collection available as template. When the convention is executed, it takes the template, adds the extensions's data to it (`addAll` for `Collections`, `source` for ConfigurableFileCollections).

I added a Gradle-like `+=` and a Kotlin-like with `add` to the sample project which gets tested. I verified that in both cases the data is kept and the extension is not modified.

This closes #203.