### PR TITLE
Restore the previous missing classes logging using DEBUG level

### DIFF
--- a/src/main/java/de/thetaphi/forbiddenapis/Checker.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/Checker.java
@@ -309,6 +309,9 @@ public final class Checker implements RelatedClassLookup, Constants {
       if (options.contains(Option.FAIL_ON_MISSING_CLASSES)) {
         throw new RelatedClassLoadingException(cnfe, origClassName);
       } else {
+        logger.debug(String.format(Locale.ENGLISH,
+            "Class '%s' cannot be loaded (while looking up details about referenced class '%s').",
+            type.getClassName(), origClassName));
         missingClasses.add(type.getClassName());
         return null;
       }

--- a/src/main/java/de/thetaphi/forbiddenapis/StdIoLogger.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/StdIoLogger.java
@@ -19,9 +19,14 @@ package de.thetaphi.forbiddenapis;
 @SuppressForbidden
 public final class StdIoLogger implements Logger {
   
-  public static final Logger INSTANCE = new StdIoLogger();
+  public static final Logger INSTANCE = new StdIoLogger(false);
+  public static final Logger INSTANCE_DEBUG = new StdIoLogger(true);
   
-  private StdIoLogger() {}
+  private final boolean debug;
+  
+  private StdIoLogger(boolean debug) {
+    this.debug = debug;
+  }
   
   @Override
   public void error(String msg) {
@@ -40,7 +45,8 @@ public final class StdIoLogger implements Logger {
   
   @Override
   public void debug(String msg) {
-    // no reporting of debug messages
+    if (debug) {
+      System.out.println("DEBUG: " + msg);
+    }
   }
-  
 }

--- a/src/main/java/de/thetaphi/forbiddenapis/StdIoLogger.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/StdIoLogger.java
@@ -46,7 +46,7 @@ public final class StdIoLogger implements Logger {
   @Override
   public void debug(String msg) {
     if (debug) {
-      System.out.println("DEBUG: " + msg);
+      System.err.println("DEBUG: " + msg);
     }
   }
 }

--- a/src/main/java/de/thetaphi/forbiddenapis/cli/CliMain.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/cli/CliMain.java
@@ -84,7 +84,7 @@ public final class CliMain implements Constants {
     final Options options = new Options();
     options.addOptionGroup(required);
     options.addOption(debugOpt = Option.builder()
-        .desc("enable debug logging")
+        .desc("enable debug logging (stderr)")
         .longOpt("debug")
         .build());
     options.addOption(classpathOpt = Option.builder("c")


### PR DESCRIPTION
Followup after after #207/#210:

- Restore the previous missing classes logging using DEBUG level
- This also adds a new `--debug` option to CLI.

This will be backported to 3.5 branch and a release is coming soon!