### PR TITLE
Add commons-io 2.15, 2.15.1

### DIFF
--- a/src/main/resources/de/thetaphi/forbiddenapis/signatures/commons-io-unsafe-2.15.0.txt
+++ b/src/main/resources/de/thetaphi/forbiddenapis/signatures/commons-io-unsafe-2.15.0.txt
@@ -1,0 +1,17 @@
+commons-io-unsafe-2.14.0.txt# (C) Copyright Uwe Schindler (Generics Policeman) and others.
+# Parts of this work are licensed to the Apache Software Foundation (ASF)
+# under one or more contributor license agreements.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@includeBundled commons-io-unsafe-2.14.0

--- a/src/main/resources/de/thetaphi/forbiddenapis/signatures/commons-io-unsafe-2.15.0.txt
+++ b/src/main/resources/de/thetaphi/forbiddenapis/signatures/commons-io-unsafe-2.15.0.txt
@@ -1,4 +1,4 @@
-commons-io-unsafe-2.14.0.txt# (C) Copyright Uwe Schindler (Generics Policeman) and others.
+# (C) Copyright Uwe Schindler (Generics Policeman) and others.
 # Parts of this work are licensed to the Apache Software Foundation (ASF)
 # under one or more contributor license agreements.
 #

--- a/src/main/resources/de/thetaphi/forbiddenapis/signatures/commons-io-unsafe-2.15.1.txt
+++ b/src/main/resources/de/thetaphi/forbiddenapis/signatures/commons-io-unsafe-2.15.1.txt
@@ -1,0 +1,17 @@
+commons-io-unsafe-2.14.0.txt# (C) Copyright Uwe Schindler (Generics Policeman) and others.
+# Parts of this work are licensed to the Apache Software Foundation (ASF)
+# under one or more contributor license agreements.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@includeBundled commons-io-unsafe-2.15.0

--- a/src/main/resources/de/thetaphi/forbiddenapis/signatures/commons-io-unsafe-2.15.1.txt
+++ b/src/main/resources/de/thetaphi/forbiddenapis/signatures/commons-io-unsafe-2.15.1.txt
@@ -1,4 +1,4 @@
-commons-io-unsafe-2.14.0.txt# (C) Copyright Uwe Schindler (Generics Policeman) and others.
+# (C) Copyright Uwe Schindler (Generics Policeman) and others.
 # Parts of this work are licensed to the Apache Software Foundation (ASF)
 # under one or more contributor license agreements.
 #


### PR DESCRIPTION
Cannot find any new scary APIs to forbid.

Prerequisite for upgrading Solr to 2.15.1 https://github.com/apache/solr/pull/2049

Fixes #240 