### PR TITLE
Explicitly enable extension functions with the XSLT factory

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -598,6 +598,10 @@
     <xslt in="src/test/antunit/dummy.xml" out="build/test-maven/fake-pom.xml"
       style="src/test/antunit/pom-generator.xsl" force="true"
     >
+      <!-- necessary to make Ant build also work when triggered within Eclipse: https://bugs.eclipse.org/bugs/show_bug.cgi?id=520437-->
+      <factory>
+        <feature name="http://www.oracle.com/xml/jaxp/properties/enableExtensionFunctions" value="true"/>
+      </factory>
       <outputproperty name="indent" value="yes"/>
       <param name="jarfiles" expression="${path.main-build.xslstr}"/>
     </xslt>


### PR DESCRIPTION
This is necessary to make Ant build work when triggered from within Eclipse with JDK9+.
A similar issue was reported in
https://bugs.eclipse.org/bugs/show_bug.cgi?id=520437

This closes #254