### PR TITLE
print cli parse error message to let user know what is missing

### DIFF
--- a/src/main/java/de/thetaphi/forbiddenapis/cli/CliMain.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/cli/CliMain.java
@@ -154,6 +154,7 @@ public final class CliMain implements Constants {
         throw new ExitException(EXIT_SUCCESS);
       }
     } catch (org.apache.commons.cli.ParseException pe) {
+      System.out.println(pe.getMessage());
       printHelp(options);
       throw new ExitException(EXIT_ERR_CMDLINE);
     }


### PR DESCRIPTION
to help users figure out what required options print the actual parse message so if you run and `-d` is missing you get:

```
Missing required option: [-d directory with class files to check for forbidden api usage; this directory is also added to classpath, -V print product version and exit, -h print this help]
```

related to #257 