### PR TITLE
Fix severity override in Ant task by using child elements (see #253)

### DIFF
--- a/src/main/docs/ant-task.html
+++ b/src/main/docs/ant-task.html
@@ -74,20 +74,6 @@ and the system classloader, not ANT's class loader.</p>
 </tr>
 
 <tr>
-  <td>signaturesWithSeveritySuppress</td>
-  <td><code>String</code></td>
-  <td></td>
-  <td>A forbidden API signature for which violations should not be reported at all (i.e. neither fail the build nor appear in the logs). This takes precedence over<code>failOnViolation</code> and <code>signaturesWithSeverityWarn</code>.</td>
-</tr>
-
-<tr>
-  <td>signaturesWithSeverityWarn</td>
-  <td><code>String</code></td>
-  <td></td>
-  <td>A forbidden API signature for which violations should be reported as warnings (i.e. not fail the build). This takes precedence over<code>failOnViolation</code>.</td>
-</tr>
-
-<tr>
   <td>classpath</td>
   <td><code>Path</code></td>
   <td></td>
@@ -217,6 +203,11 @@ code to suppress errors. Those annotations must have at least
 <code>RetentionPolicy#CLASS</code>. They can be applied to classes, their methods, or fields. By default, <code>@de.thetaphi.forbiddenapis.SuppressForbidden</code>
 can always be used, but needs the <code>forbidden-apis.jar</code> file in classpath of compiled project, which may not be wanted. Instead of a full class name, a glob
   pattern may be used (e.g., <code>**.SuppressForbidden</code>).</p>
+  
+<p>You can include multiple <code>&lt;severityOverride severity=&quot;(ERROR|WARNING|INFO|DEBUG|SUPPRESS)&quot;&gt;...signature...&lt;severityOverride&gt;</code> elements to
+override problem severity of certain signatures (i.e. not fail the build). This takes precedence over <code>failOnViolation</code>. If several signatures should get the same
+severity you can separate them by newlines. It is also possible to separate them into different elements. Each signature must be specified in exactly the same way like in the
+original signatures files!</p>
 
 </body>
 </html>

--- a/src/main/java/de/thetaphi/forbiddenapis/Checker.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/Checker.java
@@ -60,7 +60,7 @@ public final class Checker implements RelatedClassLookup, Constants {
   }
 
   public enum ViolationSeverity {
-      ERROR, WARNING, INFO, DEBUG, SUPPRESS
+    ERROR, WARNING, INFO, DEBUG, SUPPRESS
   }
 
   public final boolean isSupportedJDK;

--- a/src/main/java/de/thetaphi/forbiddenapis/Signatures.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/Signatures.java
@@ -173,7 +173,7 @@ public final class Signatures implements Constants {
     }
   }
 
-private Collection<String> getKeys(final UnresolvableReporting report, final boolean localIgnoreMissingClasses, final Set<String> missingClasses,
+  private Collection<String> getKeys(final UnresolvableReporting report, final boolean localIgnoreMissingClasses, final Set<String> missingClasses,
         final String signature) throws ParseException, IOException {
     final String clazz;
     final String field;
@@ -374,9 +374,9 @@ private Collection<String> getKeys(final UnresolvableReporting report, final boo
     return numberOfFiles == 0;
   }
   
-  public void setSignaturesSeverity(Collection<String> signature, ViolationSeverity severity) throws ParseException, IOException {
-    logger.info("Adjusting severity to " + severity + " for signatures...");
-    for (String s : signature) {
+  public void setSignaturesSeverity(Collection<String> signatures, ViolationSeverity severity) throws ParseException, IOException {
+    logger.info("Adjusting severity to " + severity + " for " + signatures.size() + " signatures...");
+    for (String s : signatures) {
       setSignatureSeverity(s, severity);
     }
   }

--- a/src/main/java/de/thetaphi/forbiddenapis/ant/SeverityOverrideType.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/ant/SeverityOverrideType.java
@@ -1,0 +1,50 @@
+/*
+ * (C) Copyright Uwe Schindler (Generics Policeman) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.thetaphi.forbiddenapis.ant;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.ProjectComponent;
+
+import de.thetaphi.forbiddenapis.Checker.ViolationSeverity;
+
+public final class SeverityOverrideType extends ProjectComponent {
+
+  private final StringBuilder signatures = new StringBuilder();
+  
+  ViolationSeverity severity = null;
+  
+  List<String> getSignatures() {
+    return Arrays.asList(signatures.toString().trim().split("\\s*[\r\n]+\\s*"));
+  }
+  
+  public void addText(String signature) {
+    this.signatures.append('\n').append(signature);
+  }
+
+  public void setSeverity(String severity) {
+    try {
+      this.severity = ViolationSeverity.valueOf(severity.toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException iae) {
+      throw new BuildException("Severity is not a valid enum value, use one of " + Arrays.toString(ViolationSeverity.values()));
+    }
+  }
+
+}

--- a/src/main/java/de/thetaphi/forbiddenapis/ant/SignaturesResources.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/ant/SignaturesResources.java
@@ -31,4 +31,9 @@ public final class SignaturesResources extends Resources {
     return task.createBundledSignatures();
   }
   
+  // we also allow to add a severity override in the <signatures/> element. Cool ne?
+  public SeverityOverrideType createSeverityOverride() {
+    return task.createSeverityOverride();
+  }
+  
 }

--- a/src/test/antunit/TestSeverityOverrides.xml
+++ b/src/test/antunit/TestSeverityOverrides.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * (C) Copyright Uwe Schindler (Generics Policeman) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+-->
+<project xmlns:au="antlib:org.apache.ant.antunit">
+
+  <fileset id="main.classes" dir="${antunit.main.classes}"/>
+  
+  <target name="testOverrideGeneral">
+    <forbiddenapis classpathref="path.all" targetVersion="${jdk.version}">
+      <fileset refid="main.classes"/>
+      <bundledSignatures name="jdk-unsafe"/>
+      java.util.Locale#ENGLISH @ We are speaking chinese here!
+      java.lang.** @ You are crazy that you disallow all java.lang
+      java.io.** @ You are crazy that you disallow all java.io
+      <severityOverride severity="warning">java.util.Locale#ENGLISH</severityOverride>
+      <severityOverride severity="debug">
+        java.lang.**
+        java.io.**
+      </severityOverride>
+    </forbiddenapis>
+    <au:assertLogContains level="info" text="Reading bundled API signatures: jdk-unsafe-${jdk.version}"/>
+    <au:assertLogContains level="info" text="Adjusting severity to WARNING for 1 signatures..."/>
+    <au:assertLogContains level="info" text="Adjusting severity to DEBUG for 2 signatures..."/>
+    <au:assertLogContains level="warning" text="java.util.Locale#ENGLISH [We are speaking chinese here!]"/>
+    <au:assertLogContains level="debug" text="java.lang.String [You are crazy that you disallow all java.lang]"/> 
+    <au:assertLogContains level="debug" text="java.lang.StringBuilder [You are crazy that you disallow all java.lang]"/> 
+    <au:assertLogContains level="debug" text="java.io.InputStream [You are crazy that you disallow all java.io]"/> 
+    <au:assertLogContains level="info" text=" 0 error(s)."/>
+  </target>
+  
+  <target name="testOverrideInSignaturesElement">
+    <forbiddenapis classpathref="path.all" targetVersion="${jdk.version}">
+      <fileset refid="main.classes"/>
+      <signatures>
+        <string>java.util.Locale#ENGLISH @ We are speaking chinese here!</string>
+        <string>java.lang.** @ You are crazy that you disallow all java.lang</string>
+        <bundled name="jdk-unsafe"/>
+        <severityOverride severity="warning">java.util.Locale#ENGLISH</severityOverride>
+        <severityOverride severity="debug">java.lang.**</severityOverride>
+      </signatures>
+    </forbiddenapis>
+    <au:assertLogContains level="info" text="Reading bundled API signatures: jdk-unsafe-${jdk.version}"/>
+    <au:assertLogContains level="info" text="Adjusting severity to WARNING for 1 signatures..."/>
+    <au:assertLogContains level="info" text="Adjusting severity to DEBUG for 1 signatures..."/>
+    <au:assertLogContains level="warning" text="java.util.Locale#ENGLISH [We are speaking chinese here!]"/>
+    <au:assertLogContains level="debug" text="java.lang.String [You are crazy that you disallow all java.lang]"/> 
+    <au:assertLogContains level="debug" text="java.lang.StringBuilder [You are crazy that you disallow all java.lang]"/> 
+    <au:assertLogContains level="info" text=" 0 error(s)."/>
+  </target>
+  
+  <target name="testDoNothingOverride">
+    <au:expectfailure expectedMessage="Check for forbidden API calls failed, see log">
+      <forbiddenapis classpathref="path.all">
+        <fileset refid="main.classes"/>
+        java.lang.String#substring(int,int) @ You are crazy that you disallow substrings
+        <severityOverride severity="error">java.lang.String#substring(int,int)</severityOverride>
+      </forbiddenapis>
+    </au:expectfailure>
+    <au:assertLogContains level="info" text="Adjusting severity to ERROR for 1 signatures..."/>
+    <au:assertLogContains level="error" text="java.lang.String#substring(int,int) [You are crazy that you disallow substrings]"/> 
+  </target>
+  
+</project>


### PR DESCRIPTION
This fixes the problems with Ant described in #253.