### PR TITLE
Refactor scanning process to include `CheckerResult` abstraction and streamline violation handling

### DIFF
--- a/src/main/java/de/thetaphi/forbiddenapis/ScanResult.java
+++ b/src/main/java/de/thetaphi/forbiddenapis/ScanResult.java
@@ -1,0 +1,31 @@
+package de.thetaphi.forbiddenapis;
+
+import java.util.List;
+
+/**
+ * Result of a single class scan.
+ */
+public final class ScanResult {
+
+  private final String className;
+  private final String sourceFile;
+  private final List<ForbiddenViolation> violations;
+
+  ScanResult(String className, String sourceFile, List<ForbiddenViolation> violations) {
+    this.className = className;
+    this.sourceFile = sourceFile;
+    this.violations = violations;
+  }
+
+  public String getClassName() {
+    return className;
+  }
+
+  public String getSourceFile() {
+    return sourceFile;
+  }
+
+  public List<ForbiddenViolation> getViolations() {
+    return violations;
+  }
+}


### PR DESCRIPTION
The idea behind this change is to enable external tools/integrations to use the results of the scan without parsing stdout to get the results.

I tried to refactor it with minimal impact. 

I read in one of your comments that you don't want to continue supporting the gradle plugin. Is this right?